### PR TITLE
Add support for OpenTTD 14 (removal of shareholders)

### DIFF
--- a/libottdadmin2/packets/server.py
+++ b/libottdadmin2/packets/server.py
@@ -312,7 +312,11 @@ class ServerCompanyInfo(Packet):
         shareholders = None
         if self.has_available_data:
             (bankruptcy_counter,) = self.read_byte()
+        # OpenTTD 14.0 removed shareholders
+        if self.has_available_data:
             shareholders = list(self.read_byte(4))
+        else:
+            shareholders = list([255, 255, 255, 255])
         return self.data(
             company_id,
             check_length(name, NETWORK_COMPANY_NAME_LENGTH, "'name'"),
@@ -367,7 +371,11 @@ class ServerCompanyUpdate(Packet):
         (colour,) = self.read_byte()
         (passworded,) = self.read_bool()
         (bankruptcy_counter,) = self.read_byte()
-        shareholders = list(self.read_byte(4))
+        # OpenTTD 14.0 removed shareholders
+        if self.has_available_data:
+            shareholders = list(self.read_byte(4))
+        else:
+            shareholders = list([255, 255, 255, 255])
         return self.data(
             company_id,
             check_length(name, NETWORK_COMPANY_NAME_LENGTH, "'name'"),


### PR DESCRIPTION
OpenTTD/OpenTTD#10709 has removed owning of company shares, and as such removed them from the `ServerCompanyUpdate` and `ServerCompanyInfo` packets. 
This means that any user that requests company updates will eventually trigger `libottdadmin2.exceptions.PacketExhaustedError: 4 bytes requested, but only 0 available` with OpenTTD 14.

I could not find any code that checks the protocol version, so I wonder whether checking protocol version for interpreting packets has even been considered. If it has, or I haven't looked in the right location, please tell me where to look.

With these packets we are lucky: the four owners are at the end of the packet, so checking whether there is more data in the packet to process is a decent way to distinguish between having or not having shareholders.
I chose to return the same type with essentially `INVALID_OWNER` as the shareholders. An alternative would be `None` or an empty `list`, but both solutions might break users. That behaviour can easily be changed if wanted, though.