### PR TITLE
Add support for public key authentication and encryption

### DIFF
--- a/examples/asyncio_basic_client.py
+++ b/examples/asyncio_basic_client.py
@@ -6,7 +6,10 @@ from libottdadmin2.client.asyncio import OttdAdminProtocol
 from libottdadmin2.constants import NETWORK_ADMIN_PORT
 
 parser = argparse.ArgumentParser(description='Connect to OpenTTD via asyncio')
-parser.add_argument('--password', default='123qwe', help="The password to connect with")
+parser.add_argument("--password", help="The password to use for authentication")
+parser.add_argument("--secret-key", help="The secret key for authentication")
+parser.add_argument("--use-insecure-join", action='store_true',
+    help="Enables joining OpenTTD servers version 14 and lower using an insecure protocol")
 parser.add_argument('--host', default='127.0.0.1', help="The host to connect to")
 parser.add_argument('--port', default=NETWORK_ADMIN_PORT, type=int, help="The port to connect to")
 
@@ -16,5 +19,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     loop = asyncio.get_event_loop()
     client = loop.run_until_complete(OttdAdminProtocol.connect(loop=loop, host=args.host, port=args.port,
-                                                               password=args.password))
+                                                               password=args.password,
+                                                               secret_key=args.secret_key,
+                                                               use_insecure_join=args.use_insecure_join))
     loop.run_until_complete(client.client_active)

--- a/examples/asyncio_custom_client.py
+++ b/examples/asyncio_custom_client.py
@@ -7,7 +7,10 @@ from libottdadmin2.client.asyncio import OttdAdminProtocol
 from libottdadmin2.constants import NETWORK_ADMIN_PORT
 
 parser = argparse.ArgumentParser(description='Connect to OpenTTD via asyncio')
-parser.add_argument('--password', default='123qwe', help="The password to connect with")
+parser.add_argument("--password", help="The password to use for authentication")
+parser.add_argument("--secret-key", help="The secret key for authentication")
+parser.add_argument("--use-insecure-join", action='store_true',
+    help="Enables joining OpenTTD servers version 14 and lower using an insecure protocol")
 parser.add_argument('--host', default='127.0.0.1', help="The host to connect to")
 parser.add_argument('--port', default=NETWORK_ADMIN_PORT, type=int, help="The port to connect to")
 
@@ -21,5 +24,8 @@ class Client(TrackingMixIn, OttdAdminProtocol):
 if __name__ == "__main__":
     args = parser.parse_args()
     loop = asyncio.get_event_loop()
-    client = loop.run_until_complete(Client.connect(loop=loop, host=args.host, port=args.port, password=args.password))
+    client = loop.run_until_complete(Client.connect(loop=loop, host=args.host, port=args.port,
+                                                    password=args.password,
+                                                    secret_key=args.secret_key,
+                                                    use_insecure_join=args.use_insecure_join))
     loop.run_until_complete(client.client_active)

--- a/examples/keygen.py
+++ b/examples/keygen.py
@@ -1,0 +1,12 @@
+from monocypher import generate_key, compute_key_exchange_public_key
+
+secret_key = generate_key()
+public_key = compute_key_exchange_public_key(secret_key)
+
+print("This is the secret key. It must not be shared and is used as command line argument for the client. It must be kept secret.")
+print(secret_key.hex())
+print()
+
+print("This is the associated public key. It may be shared and can be placed in the '[admin_authorized_keys]' section of OpenTTD's private.cfg of the server.")
+print(public_key.hex())
+print()

--- a/examples/syncio_basic_client.py
+++ b/examples/syncio_basic_client.py
@@ -5,7 +5,10 @@ from libottdadmin2.client.sync import OttdSocket, DefaultSelector
 from libottdadmin2.constants import NETWORK_ADMIN_PORT
 
 parser = argparse.ArgumentParser(description='Connect to OpenTTD via asyncio')
-parser.add_argument('--password', default='123qwe', help="The password to connect with")
+parser.add_argument("--password", help="The password to use for authentication")
+parser.add_argument("--secret-key", help="The secret key for authentication")
+parser.add_argument("--use-insecure-join", action='store_true',
+    help="Enables joining OpenTTD servers version 14 and lower using an insecure protocol")
 parser.add_argument('--host', default='127.0.0.1', help="The host to connect to")
 parser.add_argument('--port', default=NETWORK_ADMIN_PORT, type=int, help="The port to connect to")
 
@@ -14,7 +17,9 @@ logging.basicConfig(level=logging.DEBUG)
 if __name__ == "__main__":
     args = parser.parse_args()
     selector = DefaultSelector()
-    client = OttdSocket(password=args.password)
+    client = OttdSocket(password=args.password,
+                        secret_key=args.secret_key,
+                        use_insecure_join=args.use_insecure_join)
     client.connect((args.host, args.port))
     client.setblocking(False)
     client.register_to_selector(selector)

--- a/examples/syncio_custom_client.py
+++ b/examples/syncio_custom_client.py
@@ -6,7 +6,10 @@ from libottdadmin2.client.sync import OttdSocket, DefaultSelector
 from libottdadmin2.constants import NETWORK_ADMIN_PORT
 
 parser = argparse.ArgumentParser(description='Connect to OpenTTD via asyncio')
-parser.add_argument('--password', default='123qwe', help="The password to connect with")
+parser.add_argument("--password", help="The password to use for authentication")
+parser.add_argument("--secret-key", help="The secret key for authentication")
+parser.add_argument("--use-insecure-join", action='store_true',
+    help="Enables joining OpenTTD servers version 14 and lower using an insecure protocol")
 parser.add_argument('--host', default='127.0.0.1', help="The host to connect to")
 parser.add_argument('--port', default=NETWORK_ADMIN_PORT, type=int, help="The port to connect to")
 
@@ -20,7 +23,9 @@ class Client(TrackingMixIn, OttdSocket):
 if __name__ == "__main__":
     args = parser.parse_args()
     selector = DefaultSelector()
-    client = Client(password=args.password)
+    client = Client(password=args.password,
+                    secret_key=args.secret_key,
+                    use_insecure_join=args.use_insecure_join)
     client.connect((args.host, args.port))
     client.setblocking(False)
     client.register_to_selector(selector)

--- a/examples/syncio_log_client.py
+++ b/examples/syncio_log_client.py
@@ -8,7 +8,10 @@ from libottdadmin2.client.sync import OttdSocket, DefaultSelector
 from libottdadmin2.constants import NETWORK_ADMIN_PORT
 
 parser = argparse.ArgumentParser(description="Connect to OpenTTD via asyncio")
-parser.add_argument("--password", default="123qwe", help="The password to connect with")
+parser.add_argument("--password", help="The password to use for authentication")
+parser.add_argument("--secret-key", help="The secret key for authentication")
+parser.add_argument("--use-insecure-join", action='store_true',
+    help="Enables joining OpenTTD servers version 14 and lower using an insecure protocol")
 parser.add_argument("--host", default="127.0.0.1", help="The host to connect to")
 parser.add_argument(
     "--port", default=NETWORK_ADMIN_PORT, type=int, help="The port to connect to"
@@ -86,7 +89,9 @@ if __name__ == "__main__":
     logging.debug("Better get your earmuffs, this might get loud...")
     args = parser.parse_args()
     selector = DefaultSelector()
-    client = Client(password=args.password)
+    client = Client(password=args.password,
+                    secret_key=args.secret_key,
+                    use_insecure_join=args.use_insecure_join)
     client.connect((args.host, args.port))
     client.setblocking(False)
     client.register_to_selector(selector)

--- a/libottdadmin2/client/asyncio.py
+++ b/libottdadmin2/client/asyncio.py
@@ -19,7 +19,7 @@ class OttdAdminProtocol(OttdClientMixIn, asyncio.Protocol):
     def __init__(
         self,
         loop,
-        use_insecure_join: bool = True,
+        use_insecure_join: bool = False,
         password: Optional[str] = None,
         secret_key: Optional[str] = None,
         user_agent: Optional[str] = None,

--- a/libottdadmin2/client/asyncio.py
+++ b/libottdadmin2/client/asyncio.py
@@ -19,7 +19,9 @@ class OttdAdminProtocol(OttdClientMixIn, asyncio.Protocol):
     def __init__(
         self,
         loop,
+        use_insecure_join: bool = True,
         password: Optional[str] = None,
+        secret_key: Optional[str] = None,
         user_agent: Optional[str] = None,
         version: Optional[str] = None,
         **kwargs
@@ -30,7 +32,11 @@ class OttdAdminProtocol(OttdClientMixIn, asyncio.Protocol):
         self.transport = None
         self.peername = None
 
-        self.configure(password=password, user_agent=user_agent, version=version)
+        self.configure(use_insecure_join=use_insecure_join,
+                       password=password,
+                       secret_key=secret_key,
+                       user_agent=user_agent,
+                       version=version)
 
     def _close(self):
         self.transport.close()
@@ -47,7 +53,7 @@ class OttdAdminProtocol(OttdClientMixIn, asyncio.Protocol):
         self._close()
 
     def send_packet(self, packet: Packet) -> None:
-        self.transport.write(packet.write_to_buffer())
+        self.transport.write(packet.write_to_buffer(self._encryption_handler))
 
     @classmethod
     async def connect(

--- a/libottdadmin2/client/common.py
+++ b/libottdadmin2/client/common.py
@@ -27,7 +27,7 @@ class OttdClientMixIn:
 
     def configure(
         self,
-        use_insecure_join: bool = True,
+        use_insecure_join: bool = False,
         password: Optional[str] = None,
         secret_key: Optional[str] = None,
         user_agent: Optional[str] = None,

--- a/libottdadmin2/client/common.py
+++ b/libottdadmin2/client/common.py
@@ -7,30 +7,41 @@
 from asyncio import transports
 from typing import Tuple, Any, Optional
 
-from libottdadmin2.packets import AdminJoin, Packet, AdminQuit
+from libottdadmin2.client.crypto import CryptoHandler
+from libottdadmin2.packets import AdminAuthResponse, AdminJoin, AdminJoinSecure, AdminQuit, Packet
 from libottdadmin2.util import loggable, camel_to_snake
 
 
 @loggable
 class OttdClientMixIn:
     _buffer = None  # Type: bytes
+    _use_insecure_join = False # Type: bool
     _password = None  # Type: Optional[str]
     _user_agent = None  # Type: Optional[str]
     _version = None  # Type: Optional[str]
     transport = None  # Type: Optional[transports.Transport]
     peername = None  # Type: Tuple[str, int]
+    _decryption_handler = None # Type: IncrementalAuthenticatedEncryption
+    _encryption_handler = None # Type: IncrementalAuthenticatedEncryption
+    __crypto_handler = None # Type: CryptoHandler
 
     def configure(
         self,
+        use_insecure_join: bool = True,
         password: Optional[str] = None,
+        secret_key: Optional[str] = None,
         user_agent: Optional[str] = None,
         version: Optional[str] = None,
     ):
         from libottdadmin2 import VERSION
 
+        self._use_insecure_join = use_insecure_join
         self._password = password
         self._user_agent = user_agent or "libottdadmin2"
         self._version = version or VERSION
+
+        if not use_insecure_join and (password or secret_key):
+            self.__crypto_handler = CryptoHandler(password = password, secret_key = secret_key)
 
     def connection_made(self, transport: transports.Transport = None) -> None:
         if transport:
@@ -39,6 +50,14 @@ class OttdClientMixIn:
 
         self.log.info("Connection made to %s:%d", self.peername[0], self.peername[1])
 
+        if self._use_insecure_join:
+            self.insecure_join()
+        elif self.__crypto_handler != None:
+            self.secure_join()
+        else:
+            self.log.debug("No automatic authentication has been configured; provide your own!")
+
+    def insecure_join(self) -> None:
         if self._password:
             self.log.info(
                 "Automatically authenticating: %s@%s", self._user_agent, self._version
@@ -51,10 +70,24 @@ class OttdClientMixIn:
                 )
             )
 
+    def secure_join(self) -> None:
+        methods = self.__crypto_handler.get_available_methods()
+        if methods != 0:
+            self.log.info(
+                "Automatically authenticating: %s@%s", self._user_agent, self._version
+            )
+            self.send_packet(
+                AdminJoinSecure.create(
+                    name=self._user_agent,
+                    version=self._version,
+                    methods=methods,
+                )
+            )
+
     def data_received(self, data: bytes) -> None:
         self._buffer += data
         while True:
-            found, length, packet = Packet.extract(self._buffer)
+            found, length, packet = Packet.extract(self._buffer, self._decryption_handler)
             self._buffer = self._buffer[length:]
             if not found:
                 break
@@ -87,6 +120,27 @@ class OttdClientMixIn:
     def on_server_shutdown(self):
         self.log.debug("Server is shutting down")
         self.connection_closed()
+
+    def on_server_auth_request(self, method: int, public_key: bytes, key_exchange_nonce: bytes):
+        [mac, message] = self.__crypto_handler.on_auth_request(
+            method = method,
+            their_public_key = public_key,
+            key_exchange_nonce = key_exchange_nonce
+        )
+
+        self.send_packet(
+            AdminAuthResponse.create(
+                public_key = self.__crypto_handler.get_our_public_key(),
+                message = message,
+                mac = mac
+            )
+        )
+
+    def on_server_enable_encryption(self, encryption_nonce: bytes):
+        self.log.debug("Enabling encryption...")
+        self._encryption_handler = self.__crypto_handler.get_encryption_handler(encryption_nonce)
+        self._decryption_handler = self.__crypto_handler.get_decryption_handler(encryption_nonce)
+        self.__crypto_handler = None
 
 
 __all__ = [

--- a/libottdadmin2/client/crypto.py
+++ b/libottdadmin2/client/crypto.py
@@ -1,0 +1,133 @@
+#
+# This file is part of libottdadmin2
+#
+# License: http://creativecommons.org/licenses/by-nc-sa/3.0/
+#
+
+from typing import Tuple, Optional
+
+from libottdadmin2.util import loggable
+from libottdadmin2.enums import AuthenticationMethod
+
+from monocypher import Blake2b, compute_key_exchange_public_key, generate_key, IncrementalAuthenticatedEncryption, key_exchange, lock, wipe
+from os import urandom
+
+MAC_SIZE = 16 # Number of bytes for the message authentication code.
+NONCE_SIZE = 24 # Number of bytes for a nonce (random single use token).
+PUBLIC_KEY_SIZE = 32 # Number of bytes for a public key.
+HEX_SECRET_KEY_LENGTH = 64 # Size of the secret key as hexadecimal string.
+
+@loggable
+class CryptoHandler:
+    __password = None # Type: bytes
+    __our_secret_key = None # Type: bytes
+    __our_public_key = None # Type: bytes
+    __their_public_key = None # Type: bytes
+    __shared_keys = None # Type: bytes
+    __key_exchange_nonce = None # Type: bytes
+    __methods = 0
+
+    def __init__(self, password: Optional[str] = None, secret_key: Optional[str] = None):
+        """Create the crypto handler with the given password and secret key.
+
+        When the password is set, it must not be empty. Setting the password enables
+        X25519 password authenticated key exchange.
+        When the secret key is set, it must be exactly 64 hexadecimal characters. Setting
+        the secret key enables X25519 authorized key authentication. Not setting the
+        secret key causes a new random secret key to be generated for this handler.
+
+        Note: when neither a password nor secret key are given, this handler will not have
+        any available authentication methods and any attempt of authentication will fail.
+
+        :param password: Optional password to enable password authentication.
+        :param secret_key: Optional secret key for authorized key authentication.
+        """
+        if password:
+            if len(password) == 0:
+                raise ValueError("The password must not be empty")
+            self.__methods |= 1 << AuthenticationMethod.X25519_PAKE
+        if secret_key:
+            if len(secret_key) != HEX_SECRET_KEY_LENGTH:
+                raise ValueError("The hexadecimal secret-key must be exactly %d characters, is was %d characters" % (HEX_SECRET_KEY_LENGTH, len(secret_key)))
+            self.__methods |= 1 << AuthenticationMethod.X25519_AUTHORIZED_KEY
+
+        self.__password = bytes(password, 'utf-8')
+        self.__our_secret_key = generate_key() if secret_key is None else bytes.fromhex(secret_key)
+        self.__our_public_key = compute_key_exchange_public_key(self.__our_secret_key)
+
+    def get_available_methods(self) -> int:
+        """Get the authentication methods that this handler is configured for as bitmask."""
+        return self.__methods
+
+    def get_our_public_key(self) -> bytes:
+        """Get the public key associated with the private key of this handler."""
+        return self.__our_public_key
+
+    def get_encryption_handler(self, encryption_nonce: bytes) -> IncrementalAuthenticatedEncryption:
+        """Get the handler for performing the encryption for sending data to the server"""
+        return IncrementalAuthenticatedEncryption(
+            key = self.__shared_keys[:32],
+            nonce = encryption_nonce
+        )
+
+    def get_decryption_handler(self, encryption_nonce: bytes) -> IncrementalAuthenticatedEncryption:
+        """Get the handler for performing the decryption of received data from the server"""
+        return IncrementalAuthenticatedEncryption(
+            key = self.__shared_keys[32:],
+            nonce = encryption_nonce
+        )
+
+    def __x25519_auth(self, payload: bytes) -> Tuple[bytes, bytes]:
+        shared_secret = key_exchange(self.__our_secret_key, self.__their_public_key)
+
+        digest = Blake2b(hash_size = 64)
+        digest.update(shared_secret)
+        digest.update(self.__their_public_key) # The server's public key
+        digest.update(self.__our_public_key) # The client's public key
+        digest.update(payload)
+        self.__shared_keys = digest.finalize()
+
+        wipe(shared_secret)
+
+        return lock(
+            key = self.__shared_keys[:32],
+            nonce = self.__key_exchange_nonce,
+            message = urandom(8),
+            associated_data = self.__our_public_key
+        )
+
+    def on_auth_request(self, method: int, their_public_key: bytes, key_exchange_nonce: bytes) -> Tuple[bytes, bytes]:
+        """Create the reply of the key exchange for an authentication request.
+
+        This currently supports X25519 password authenticated key exchange, which uses the password
+        locally to construct the shared key between the client and server, and using the message
+        authentication code the server can check whether the client knows the password without ever
+        sending the password over the network. Next to this there is X25519 authorized key, which
+        uses our secret key to do the key exchange and create the shared secret, and using the
+        message authentication code the server can check whether the public key the client sends
+        is associated with the client's secret key. After this the server checks whether our public
+        key is in their list of allowed/authorized keys to login (without password).
+
+        :param method: The authentication method to perform.
+        :param their_public_key: The public key as received from the server.
+        :param key_exchange_nonce: The nonce, or one time token, as generated by the server for the key exchange.
+
+        :return: Tuple with the MAC (message authentication code) and ciphertext, or None on an error.
+        """
+        self.__their_public_key = their_public_key
+        self.__key_exchange_nonce = key_exchange_nonce
+
+        if (self.__methods & (1 << method)) == 0:
+            self.log.error("Received method that was not requested")
+            return None;
+
+        if method == AuthenticationMethod.X25519_PAKE:
+            self.log.debug("Authenticating using password authenticated key exchange")
+            return self.__x25519_auth(self.__password)
+
+        if method == AuthenticationMethod.X25519_AUTHORIZED_KEY:
+            self.log.debug("Authenticating using authorized key")
+            return self.__x25519_auth(bytes())
+
+        self.log.error("Unknown method")
+        return None

--- a/libottdadmin2/client/sync.py
+++ b/libottdadmin2/client/sync.py
@@ -19,7 +19,7 @@ from libottdadmin2.util import loggable
 class OttdSocket(OttdClientMixIn, socket.socket):
     def __init__(
         self,
-        use_insecure_join: bool = True,
+        use_insecure_join: bool = False,
         password: Optional[str] = None,
         secret_key: Optional[str] = None,
         user_agent: Optional[str] = None,

--- a/libottdadmin2/client/sync.py
+++ b/libottdadmin2/client/sync.py
@@ -19,7 +19,9 @@ from libottdadmin2.util import loggable
 class OttdSocket(OttdClientMixIn, socket.socket):
     def __init__(
         self,
+        use_insecure_join: bool = True,
         password: Optional[str] = None,
+        secret_key: Optional[str] = None,
         user_agent: Optional[str] = None,
         version: Optional[str] = None,
     ):
@@ -29,7 +31,11 @@ class OttdSocket(OttdClientMixIn, socket.socket):
         self._last_error = None
         self._buffer = b""
         self._selector = None  # Type: Optional[_BaseSelectorImpl]
-        self.configure(password=password, user_agent=user_agent, version=version)
+        self.configure(use_insecure_join=use_insecure_join,
+                       password=password,
+                       secret_key=secret_key,
+                       user_agent=user_agent,
+                       version=version)
 
     def connect(self, address: Union[tuple, str, bytes]) -> bool:
         try:
@@ -62,7 +68,7 @@ class OttdSocket(OttdClientMixIn, socket.socket):
 
     def send_packet(self, packet: Packet):
         try:
-            self.sendall(packet.write_to_buffer())
+            self.sendall(packet.write_to_buffer(self._encryption_handler))
         except socket.error as e:
             self._last_error = e
             self.connection_lost(e)

--- a/libottdadmin2/enums.py
+++ b/libottdadmin2/enums.py
@@ -188,3 +188,9 @@ class Language(IntEnum):
     GREEK = 0x22
     LATVIAN = 0x23
     COUNT = 0x24
+
+
+class AuthenticationMethod(IntEnum):
+    X25519_PAKE = 0x01  # Authentication using x25519 password-authenticated key agreement.
+    X25519_AUTHORIZED_KEY = 0x02  # Authentication using x22519 key exchange and authorized keys.
+    _END = 0x03  # Sentinel for end.

--- a/libottdadmin2/enums.py
+++ b/libottdadmin2/enums.py
@@ -119,7 +119,10 @@ class ErrorCode(IntEnum):
     TIMEOUT_COMPUTER = 0x11
     TIMEOUT_MAP = 0x12
     TIMEOUT_JOIN = 0x13
-    _END = 0x14
+    INVALID_CLIENT_NAME = 0x14
+    NOT_ON_ALLOW_LIST = 0x15
+    NO_AUTHENTICATION_METHOD_AVAILABLE = 0x16
+    _END = 0x17
 
 
 class Colour(IntEnum):

--- a/libottdadmin2/packets/__init__.py
+++ b/libottdadmin2/packets/__init__.py
@@ -6,9 +6,11 @@
 
 from libottdadmin2.packets.base import Packet
 from libottdadmin2.packets.admin import (
+    AdminAuthResponse,
     AdminChat,
     AdminGamescript,
     AdminJoin,
+    AdminJoinSecure,
     AdminPing,
     AdminPoll,
     AdminQuit,
@@ -43,10 +45,12 @@ from libottdadmin2.packets.server import (
     ServerGamescript,
     ServerRconEnd,
     ServerPong,
+    ServerAuthRequest,
 )
 
 __all__ = [
     "Packet",
+    "ServerAuthRequest",
     "ServerBanned",
     "ServerChat",
     "ServerClientError",
@@ -74,9 +78,11 @@ __all__ = [
     "ServerRconEnd",
     "ServerShutdown",
     "ServerWelcome",
+    "AdminAuthResponse",
     "AdminChat",
     "AdminGamescript",
     "AdminJoin",
+    "AdminJoinSecure",
     "AdminPing",
     "AdminPoll",
     "AdminQuit",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pymonocypher ~= 4.0.2


### PR DESCRIPTION
With OpenTTD/OpenTTD#11878 a new and more secure way of doing authentication is added. To test these changes in OpenTTD, I needed a client and I used this one so why not try to upstream these changes. This branch has not been merged, and if it will be merged it is going to be slated for version 15 of OpenTTD so there is no real hurry yet.

The concept of the new authentication is that there is a private-public key exchange using X25519. Essentially the maths works out that you can generate a shared secret by knowing each other's public key, your own private key and some random (unique) data.
With this shared secret a new encryption key is derived, which is done by hashing some values together. With this encryption key a message is encrypted and sent back to the server, which performs the same steps and checks whether it can decrypt the message and whether the signature is valid. If that works out some further checks can be done at the server side.

Currently there are two methods:
* password authenticated key exchange; here the password is one of the values that get hashed together, and as such is used to generate the encryption key. If you pass the wrong password, your encryption key will be different from the server's encryption key, and anything the client encrypts cannot be decrypted and validated by the server. This means that it can check for knowledge of the password without actually sending the password.
* authorized keys; here the user generates a secret and public key. The user configures the client to use the secret key, and sends the public key to the server owner to put in their list of allowed (public) keys. Due to the key exchange only working with one of the two secret keys and both public keys, the client proves that it is the owner of the secret key associated with the public key and the server checks whether that public key is authorized.

The latter allows more fine-grained control to who may login at any time, as each client is essentially an unique entity. 
The biggest caveat is that the current join packet contains the password, and we do not want to send the password any more over the wire, so a new join packet has been introduced. In this packet the client can tell which authentication methods it support, e.g. if the user does not pass a password, then it can leave out that method.

The server will choose the "best" method for logging in, which favours authorized keys if that's supported by the client. When that fails, it will fall back to the password variant if the client supports that and the server has a password set.

After authentication using the new join packet the data on the network will be encrypted using the encryption keys generated by the last key exchange.
With the old join packet everything remains as it is, so password without encryption over the wire and no encryption for the data. The default for OpenTTD will be to disable that insecure version, and I added a commit to change the default in this project to the secure join method (the last one). Maybe that commit needs to be merged later, when 15 is near and clients should use that as for the current OpenTTD versions the secure join method simply will not work, and it will forcefully close the connection.


For this change there is a requirement on some cryptography library. The problem is that the "standard" ones do not have all the functionality that is required, so you'd need to pick and choose.
To prevent any kind of inconsistency issues with the different implementations, I have looked into Python wrappers around the library that OpenTTD uses: Monocypher. That exists in the form of pymonocypher.
The "only" problem as of writing is that the current version is an old version, which behaves slightly different from the newer version used in OpenTTD. Next to that the stuff for streaming encryption is not exposed yet, so I made a few pull requests to get a newer version and expose that: jetperch/pymonocypher#8.

That does mean that this PR cannot be merged yet, because it depends on an unreleased version of pymonocypher and because the feature has not been merged into OpenTTD yet. But it gives you some time to gather your thoughts on this PR.
I hope I didn't butcher this library and Python too much ;)


Since the crypto.py part might be useful to be used for other projects talking to OpenTTD, I'll hereby also license it under the GNU Lesser General Public License version 2.1 (LGPL 2.1).